### PR TITLE
Do teardown in create-environment

### DIFF
--- a/scripts/HyperV/scripts/create-environment.ps1
+++ b/scripts/HyperV/scripts/create-environment.ps1
@@ -10,6 +10,10 @@ Param(
 #  folder                                                                  #
 ############################################################################
 
+# Do teardown
+& 'C:\OpenStack\devstack\scripts\teardown.ps1'
+
+
 $virtualenv = "c:\OpenStack\virtualenv"
 $openstackDir = "C:\OpenStack"
 $baseDir = "$openstackDir\devstack"


### PR DESCRIPTION
If executed with retry, create-environment will fail its sanity
checks.
