### PR TITLE
Forced oslo.log==1.1.0 on windows

### DIFF
--- a/scripts/HyperV/scripts/create-environment.ps1
+++ b/scripts/HyperV/scripts/create-environment.ps1
@@ -256,6 +256,8 @@ FixExecScript "$virtualenv\Scripts\neutron-hyperv-agent-script.py"
 Remove-Item -Recurse -Force "$remoteConfigs\$hostname\*"
 Copy-Item -Recurse $configDir "$remoteConfigs\$hostname"
 
+pip install oslo.log==1.1.0
+
 Write-Host "Starting the services"
 Try
 {


### PR DESCRIPTION
oslo.log==1.2.0 (latest on 27.05.2015) has issues because it tries to
import syslog on windows

Signe-off-by: Victor Laza <vlaza@cloudbasesolutions.com>